### PR TITLE
fix: #39 : 채팅개발

### DIFF
--- a/glint/build.gradle
+++ b/glint/build.gradle
@@ -36,6 +36,11 @@ dependencies {
     implementation 'org.redisson:redisson-spring-boot-starter:3.32.0'
     implementation 'com.auth0:java-jwt:4.4.0'
 
+    //STOMP
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.webjars:sockjs-client:1.5.1'
+    implementation 'org.webjars:stomp-websocket:2.3.4'
+
     runtimeOnly 'com.mysql:mysql-connector-j'
     //AWS Parameter Store
     implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1')
@@ -47,6 +52,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     runtimeOnly  'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly  'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    //mongoDB
+//    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/glint/src/main/java/com/swyp/glint/chatting/api/ChatController.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/api/ChatController.java
@@ -1,0 +1,50 @@
+package com.swyp.glint.chatting.api;
+
+import com.swyp.glint.chatting.application.ChatService;
+import com.swyp.glint.chatting.application.dto.request.CreateChatMessageRequest;
+import com.swyp.glint.chatting.application.dto.response.ChatResponse;
+import com.swyp.glint.chatting.application.dto.response.ChatResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final SimpMessagingTemplate simpMessagingTemplate;
+
+    private final ChatService chatService;
+
+    @MessageMapping("/chatrooms/{roomId}/chats")
+    public ChatResponse chatting(@DestinationVariable Long roomId, @RequestBody CreateChatMessageRequest request) {
+        simpMessagingTemplate.convertAndSend("/api/sub/chatrooms/" + roomId, request.message());
+        return chatService.createChatMessage(request);
+    }
+
+    @GetMapping(path = "/chatrooms/{roomId}/chats", produces = "application/json")
+    @Operation(summary = "채팅방 메시지 조회, paging", description = "채팅방 페이징방식 메시지 조회")
+    public ChatResponses getChatMessage(
+            @PathVariable Long roomId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size
+            ) {
+        return chatService.getChatMessage(roomId, page, size);
+    }
+
+    @Operation(summary = "채팅방 메시지 조회, noOffSet", description = "채팅방 noOffSet방식 메시지 조회, lastChatId가 null이면 최신 메시지부터 조회")
+    @GetMapping(path = "/chatrooms/{roomId}/chats/no-offset", produces = "application/json")
+    public ChatResponses getChatMessageNoOffset(
+            @RequestParam(required = false) Long lastChatId,
+            @PathVariable Long roomId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size
+    ) {
+        return chatService.getChatMessageNoOffset(lastChatId, roomId, size);
+    }
+
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/api/ChatRoomController.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/api/ChatRoomController.java
@@ -1,0 +1,30 @@
+package com.swyp.glint.chatting.api;
+
+import com.swyp.glint.chatting.application.ChatRoomService;
+import com.swyp.glint.chatting.application.dto.ChatRoomRequest;
+import com.swyp.glint.chatting.application.dto.response.ChatRoomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping()
+@RequiredArgsConstructor
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    @Operation(summary = "채팅방 생성", description = "User Id를 통한 User 정보 조회")
+    @PostMapping(path = "/meetings/{meetingId}/chatrooms", consumes = "application/json", produces = "application/json")
+    public ChatRoomResponse createChatRoom(@PathVariable Long meetingId, @RequestBody ChatRoomRequest chatRoomRequest) {
+        return chatRoomService.createChatRoom(meetingId, chatRoomRequest);
+    }
+
+
+    @Operation(summary = "채팅방 조회", description = "Metting Id를 통한 채팅방 정보 조회")
+    @GetMapping(path = "/meetings/{meetingId}/chatrooms", consumes = "application/json", produces = "application/json")
+    public ChatRoomResponse geteChatRoom(@PathVariable Long meetingId) {
+        return chatRoomService.getChatRoomByMeetingId(meetingId);
+    }
+
+
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/application/ChatRoomService.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/application/ChatRoomService.java
@@ -1,0 +1,66 @@
+package com.swyp.glint.chatting.application;
+
+import com.swyp.glint.chatting.application.dto.ChatRoomRequest;
+import com.swyp.glint.chatting.application.dto.response.ChatRoomResponse;
+import com.swyp.glint.chatting.domain.ChatRoom;
+import com.swyp.glint.chatting.repository.ChatRoomRepository;
+import com.swyp.glint.common.exception.InvalidValueException;
+import com.swyp.glint.common.exception.NotFoundEntityException;
+import com.swyp.glint.meeting.application.MeetingService;
+import com.swyp.glint.meeting.domain.Meeting;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    private final MeetingService meetingService;
+
+    public ChatRoomResponse createChatRoom(Long meetingId, ChatRoomRequest chatRoomRequest) {
+        ChatRoom chatRoom = chatRoomRequest.toEntity(meetingId);
+
+        //todo 요청 유저가 미팅에 모두 속해있는지 검증 로직 추가
+//        Meeting meeting = meetingService.getMeeting(chatRoom.getMeetingId());
+//
+//        List<Long> invalidUserIds = meeting.isJoinUsers(chatRoom.getUserIds());
+//        if(!invalidUserIds.isEmpty()) {
+//            throw new InvalidValueException("Invalid User Contain" + invalidUserIds);
+//        }
+
+        return ChatRoomResponse.from(chatRoomRepository.save(chatRoom));
+    }
+
+    @Transactional
+    public void removeChatRoom(Long meetingId) {
+        ChatRoom chatRoom = chatRoomRepository.findByMeetingId(meetingId)
+                .orElseThrow(() -> new NotFoundEntityException("Not Found ChatRoom MeetingId" + meetingId));
+
+        chatRoom.archive();
+
+        chatRoomRepository.save(chatRoom);
+    }
+
+    public void activeChatRoom(Long meetingId) {
+        ChatRoom chatRoom = chatRoomRepository.findByMeetingId(meetingId)
+                .orElseThrow(() -> new NotFoundEntityException("Not Found ChatRoom MeetingId" + meetingId));
+
+        chatRoom.active();
+
+        chatRoomRepository.save(chatRoom);
+    }
+
+
+    public ChatRoom getChatRoom(Long chatRoomId) {
+        return chatRoomRepository.findById(chatRoomId).orElseThrow(() -> new NotFoundEntityException("Not Found ChatRoom Id : " + chatRoomId));
+    }
+
+    public ChatRoomResponse getChatRoomByMeetingId(Long meetingId) {
+        return ChatRoomResponse.from(chatRoomRepository.findByMeetingId(meetingId).orElseThrow(() -> new NotFoundEntityException("Not Found ChatRoom meetingId : " + meetingId)));
+    }
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/application/ChatService.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/application/ChatService.java
@@ -1,0 +1,79 @@
+package com.swyp.glint.chatting.application;
+
+import com.swyp.glint.chatting.application.dto.request.CreateChatMessageRequest;
+import com.swyp.glint.chatting.application.dto.response.ChatResponse;
+import com.swyp.glint.chatting.application.dto.response.ChatResponses;
+import com.swyp.glint.chatting.domain.Chat;
+import com.swyp.glint.chatting.domain.ChatRoom;
+import com.swyp.glint.chatting.repository.ChatRepository;
+import com.swyp.glint.common.exception.InvalidValueException;
+import com.swyp.glint.common.exception.NotFoundEntityException;
+import com.swyp.glint.meeting.application.MeetingService;
+import com.swyp.glint.user.application.UserFacade;
+import com.swyp.glint.user.domain.UserDetailAggregation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatRepository chatRepository;
+
+    private final UserFacade userFacade;
+
+    private final ChatRoomService chatRoomService;
+
+    private final MeetingService meetingService;
+
+
+    public ChatResponse createChatMessage(CreateChatMessageRequest createChatMessageRequest) {
+        Chat chat = createChatMessageRequest.toEntity();
+
+        ChatRoom chatRoom = chatRoomService.getChatRoom(chat.getChatRoomId());
+
+        // 미팅에 속한 유저인지 검증 로직 추후 추가 예정
+//        Meeting meeting = meetingService.getMeeing(chatRoom.getMeetingId());
+//
+//        if(!meeting.isJoinUser(chat.getSendUserId())) {
+//            log.error("Not Join User, SendUserId : {} MeetingId : {}", chat.getSendUserId(), chatRoom.getMeetingId());
+//            throw new InvalidValueException("Not Join User, SendUserId : " + chat.getSendUserId() + " MeetingId : " + chatRoom.getMeetingId());
+//        }
+
+        if(!chatRoom.isActivated()) {
+            log.error("Not Active ChatRoom, ChatRoomId : {}", chatRoom.getId());
+            throw new InvalidValueException("Not Active ChatRoom, ChatRoomId : " + chatRoom.getId());
+        }
+
+        UserDetailAggregation userDetailAggregation = userFacade.getUserDetailAggregation(chat.getSendUserId());
+        chatRepository.save(chat);
+
+        return ChatResponse.of(chat, userDetailAggregation);
+    }
+
+
+    public ChatResponses getChatMessage(Long roomId, int page, int size) {
+        //TODO
+        // noOffset 방식, Monogo로 전환하기
+        return ChatResponses.of(chatRepository.findAllByChatRoomIdOrderBySendDateAtDesc(roomId, PageRequest.of(page, size)));
+    }
+
+    public ChatResponses getChatMessageNoOffset(Long lastChatId, Long chatRoomId, Integer size) {
+        lastChatId = Optional.ofNullable(lastChatId)
+                .orElseGet(() -> {
+                    return chatRepository.findTop1ByChatRoomIdOrderByIdDesc(chatRoomId)
+                            .map(Chat::getId)
+                            .orElse(0L);
+                });
+
+
+        return ChatResponses.of(chatRepository.findAllByChatRoomIdOrderByIdDesc(chatRoomId, lastChatId, PageRequest.of(0, size)));
+    }
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/application/dto/ChatRoomRequest.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/application/dto/ChatRoomRequest.java
@@ -1,0 +1,24 @@
+package com.swyp.glint.chatting.application.dto;
+
+import com.swyp.glint.chatting.domain.ChatRoom;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+public record ChatRoomRequest(
+        @Parameter(description = "채팅방 참여 userId List", example = "[1,2,3]", required = true)
+        List<Long> userIds
+) {
+
+
+    public ChatRoom toEntity(Long meetingId) {
+        return ChatRoom.createByMeeting(meetingId, userIds());
+    }
+
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/application/dto/request/CreateChatMessageRequest.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/application/dto/request/CreateChatMessageRequest.java
@@ -1,0 +1,25 @@
+package com.swyp.glint.chatting.application.dto.request;
+
+import com.swyp.glint.chatting.domain.Chat;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public record CreateChatMessageRequest(
+        Long userId,
+        Long chatroomId,
+        String message,
+        String sendDate
+) {
+
+    public Chat toEntity() {
+        return Chat.create(
+                message,
+                userId,
+                chatroomId,
+                LocalDateTime.parse(sendDate, DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+        );
+    }
+
+
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/application/dto/response/ChatResponse.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/application/dto/response/ChatResponse.java
@@ -1,0 +1,42 @@
+package com.swyp.glint.chatting.application.dto.response;
+
+import com.swyp.glint.chatting.domain.Chat;
+import com.swyp.glint.user.domain.UserDetailAggregation;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Builder
+public record ChatResponse(
+        Long id,
+        String message,
+        Long chatRoomId,
+        Long userId,
+        String nickname,
+        String userProfileImageUrl,
+        LocalDateTime sendDate
+) {
+
+    public ChatResponse(Long id, String message, Long chatRoomId, Long userId, String nickname, String userProfileImageUrl, LocalDateTime sendDate) {
+        this.id = id;
+        this.message = message;
+        this.chatRoomId = chatRoomId;
+        this.userId = userId;
+        this.nickname = nickname;
+        this.userProfileImageUrl = userProfileImageUrl;
+        this.sendDate = sendDate;
+    }
+
+    public static ChatResponse of(Chat chat, UserDetailAggregation userDetailAggregation) {
+        return ChatResponse.builder()
+                .id(chat.getId())
+                .message(chat.getMessage())
+                .chatRoomId(chat.getChatRoomId())
+                .userId(userDetailAggregation.getUserId())
+                .nickname(userDetailAggregation.getNickname())
+                .sendDate(chat.getSendDate())
+                .build();
+    }
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/application/dto/response/ChatResponses.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/application/dto/response/ChatResponses.java
@@ -1,0 +1,20 @@
+package com.swyp.glint.chatting.application.dto.response;
+
+import com.swyp.glint.chatting.domain.Chat;
+import com.swyp.glint.user.domain.UserDetailAggregation;
+import lombok.Builder;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Builder
+public record ChatResponses(
+        List<ChatResponse> chats
+) {
+
+    public static ChatResponses of(List<ChatResponse> chatResponseList) {
+        return ChatResponses.builder()
+                .chats(chatResponseList)
+                .build();
+    }
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/application/dto/response/ChatRoomResponse.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/application/dto/response/ChatRoomResponse.java
@@ -1,0 +1,36 @@
+package com.swyp.glint.chatting.application.dto.response;
+
+import com.swyp.glint.chatting.domain.ChatRoom;
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.util.List;
+
+public record ChatRoomResponse(
+        @Parameter(description = "채팅방 ID", example = "1", required = true)
+        Long chatRoomId,
+        @Parameter(description = "Meeting ID", example = "1", required = true)
+        Long meetingId,
+        @Parameter(description = "채팅방 참여 userId List", example = "[1,2,3]", required = true)
+        List<Long> userIds,
+        @Parameter(description = "채팅방 이름", example = "채팅방", required = true)
+        String name,
+        @Parameter(description = "채팅방 활성화 여부", example = "true", required = true)
+        Boolean isActivated,
+        @Parameter(description = "채팅방 아카이브 여부", example = "false", required = true)
+        Boolean isArchived
+) {
+
+
+    public static ChatRoomResponse from(ChatRoom chatRoom) {
+        return new ChatRoomResponse(
+                chatRoom.getId(),
+                chatRoom.getMeetingId(),
+                chatRoom.getUserIds(),
+                chatRoom.getName(),
+                chatRoom.isActivated(),
+                chatRoom.getIsArchived()
+        );
+    }
+
+
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/application/dto/response/ChatUserResponse.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/application/dto/response/ChatUserResponse.java
@@ -1,0 +1,20 @@
+package com.swyp.glint.chatting.application.dto.response;
+
+import com.swyp.glint.user.domain.User;
+import lombok.Builder;
+
+public class ChatUserResponse {
+
+    private Long userId;
+    private String name;
+    private String profileImageUrl;
+
+    private ChatUserResponse(Long userId, String name, String profileImageUrl) {
+        this.userId = userId;
+        this.name = name;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+
+
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/config/WebSocketConfig.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/config/WebSocketConfig.java
@@ -1,0 +1,53 @@
+package com.swyp.glint.chatting.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+
+    /**
+     * 메시지 브로커 설정을 위한 메소드
+     * /api/sub -> 메세지 구독(수신)
+     * /api/pub -> 메세지 발행(송신)
+     * @param registry
+     */
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        /* 메시지 앞에 해당 prefix로 해당 경로를 처리하고 있는 핸들러로 전달된다. */
+        registry.setApplicationDestinationPrefixes("/pub");
+        registry.enableSimpleBroker("/sub");
+    }
+
+
+    /**
+     * 해당 엔드포인트로 요청 시 소켓 연결
+     * @param registry
+     */
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry
+                .addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+//                .withSockJS();
+                ;
+    }
+
+
+    /**
+     * 클라이언트로부터 들어오는 요청을 처리하기 위한 채널 설정
+     * 요청전 인터셉터를 설정 (e.g. Token 인증)
+     * @param registration
+     */
+//    @Override
+//    public void configureClientInboundChannel(ChannelRegistration registration) {
+//        registration.interceptors(stompHandler);
+//    }
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/domain/Chat.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/domain/Chat.java
@@ -1,0 +1,55 @@
+package com.swyp.glint.chatting.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+import java.time.LocalDateTime;
+
+@Table(name = "chat")
+@Entity
+//mongoDB시 사용예정
+//@Document(collection = "chat")
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class Chat {
+
+    @Id
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+    private Long id;
+
+    private String message;
+
+    private Long sendUserId;
+
+    private Long chatRoomId;
+
+    private LocalDateTime sendDate;
+
+
+    @Builder(access = lombok.AccessLevel.PRIVATE)
+    private Chat(Long id, String message, Long sendUserId, Long chatRoomId, LocalDateTime sendDate) {
+        this.id = id;
+        this.message = message;
+        this.sendUserId = sendUserId;
+        this.chatRoomId = chatRoomId;
+        this.sendDate = sendDate;
+    }
+
+    public static Chat create(String message, Long sendUserId, Long chatRoomId, LocalDateTime sendDate) {
+        return Chat.builder()
+                .message(message)
+                .sendUserId(sendUserId)
+                .chatRoomId(chatRoomId)
+                .sendDate(sendDate)
+                .build();
+    }
+
+
+
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/domain/ChatRoom.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/domain/ChatRoom.java
@@ -1,0 +1,76 @@
+package com.swyp.glint.chatting.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Table(name = "chat_room")
+@Entity
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+    Long id;
+
+    @Column(name = "meeting_id")
+    Long meetingId;
+
+    @ElementCollection
+    @Column(name = "user_id")
+    List<Long> userIds;
+
+    @Column(name = "name")
+    String name;
+
+    @Column(name = "is_activated")
+    Boolean isActivated;
+
+    @Column(name = "is_archived")
+    Boolean isArchived;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ChatRoom(Long id, Long meetingId, List<Long> userIds, String name, boolean isActivated, boolean isArchived) {
+        this.id = id;
+        this.meetingId = meetingId;
+        this.userIds = userIds;
+        this.name = name;
+        this.isActivated = isActivated;
+        this.isArchived = isArchived;
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public static ChatRoom createByMeeting(Long meetingId, List<Long> userIds) {
+        return ChatRoom.builder()
+                .userIds(userIds)
+                .meetingId(meetingId)
+                .isActivated(false)
+                .isArchived(false)
+                .build();
+    }
+
+    public void archive() {
+        this.isArchived = true;
+    }
+
+
+    public void active() {
+        this.isActivated = true;
+    }
+
+    public boolean isActivated() {
+        return this.isActivated;
+    }
+
+    public boolean isJoinUser(Long sendUserId) {
+
+        return false;
+    }
+}
+
+

--- a/glint/src/main/java/com/swyp/glint/chatting/domain/UserChat.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/domain/UserChat.java
@@ -1,0 +1,44 @@
+package com.swyp.glint.chatting.domain;
+
+import com.swyp.glint.user.domain.User;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class UserChat {
+
+    private Long chatId;
+
+    private String message;
+
+    private User sendUser;
+
+    private Long chatRoomId;
+
+    private LocalDateTime sendDate;
+
+    @Builder(access = lombok.AccessLevel.PRIVATE)
+    private UserChat(Long chatId, String message, User sendUser, Long chatRoomId, LocalDateTime sendDate) {
+        this.chatId = chatId;
+        this.message = message;
+        this.sendUser = sendUser;
+        this.chatRoomId = chatRoomId;
+        this.sendDate = sendDate;
+    }
+
+    public static UserChat of(Long chatId, String message, User sendUser, Long chatRoomId, LocalDateTime sendDate) {
+        return UserChat.builder()
+                .chatId(chatId)
+                .message(message)
+                .sendUser(sendUser)
+                .chatRoomId(chatRoomId)
+                .sendDate(sendDate)
+                .build();
+    }
+
+
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/repository/ChatMongoRepository.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/repository/ChatMongoRepository.java
@@ -1,0 +1,31 @@
+package com.swyp.glint.chatting.repository;
+
+import com.swyp.glint.chatting.application.dto.response.ChatResponse;
+import com.swyp.glint.chatting.domain.Chat;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+//
+//@Repository
+//public interface ChatMongoRepository extends MongoRepository<Chat, String> {
+//
+////    @Query("""
+////            select new com.swyp.glint.chatting.application.dto.response.ChatResponse(
+////                c.id, c.message, c.chatRoomId, u.id, ud.nickname, ud.profileImage, c.sendDate
+////            )
+////            FROM Chat c join User u on c.sendUserId = u.id
+////            join UserDetail ud on u.id = ud.userId
+////            WHERE c.chatRoomId = :roomId
+////            ORDER BY c.sendDate DESC
+////    """)
+////    List<ChatResponse> findAllByChatRoomIdOrderBySendDateAtDesc(Long roomId, PageRequest pageRequest);
+//
+//
+//    @Query("""
+//           {'chatRoomId': ?0}
+//    """)
+//    List<ChatResponse> tfindAllByChatRoomIdOrderBySendDateAtDesc(Long roomId, PageRequest pageRequest);
+//}

--- a/glint/src/main/java/com/swyp/glint/chatting/repository/ChatRepository.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/repository/ChatRepository.java
@@ -1,0 +1,42 @@
+package com.swyp.glint.chatting.repository;
+
+import com.swyp.glint.chatting.application.dto.response.ChatResponse;
+import com.swyp.glint.chatting.domain.Chat;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChatRepository extends JpaRepository<Chat, String> {
+
+    @Query("""
+            SELECT new com.swyp.glint.chatting.application.dto.response.ChatResponse(
+                c.id, c.message, c.chatRoomId, u.id, ud.nickname, ud.profileImage, c.sendDate
+            )
+            FROM Chat c join User u on c.sendUserId = u.id
+            join UserDetail ud on u.id = ud.userId
+            WHERE c.chatRoomId = :roomId
+            ORDER BY c.sendDate DESC
+    """)
+    List<ChatResponse> findAllByChatRoomIdOrderBySendDateAtDesc(Long roomId, PageRequest pageRequest);
+
+    @Query("""
+            SELECT new com.swyp.glint.chatting.application.dto.response.ChatResponse(
+                c.id, c.message, c.chatRoomId, u.id, ud.nickname, ud.profileImage, c.sendDate
+            )
+            FROM Chat c join User u on c.sendUserId = u.id
+            join UserDetail ud on u.id = ud.userId
+            WHERE c.chatRoomId = :roomId
+            AND c.id < :lastChatId
+            ORDER BY c.id DESC
+    """)
+    List<ChatResponse> findAllByChatRoomIdOrderByIdDesc(Long roomId, Long lastChatId, PageRequest pageRequest);
+
+
+    Optional<Chat> findTop1ByChatRoomIdOrderByIdDesc(Long chatRoomId);
+}

--- a/glint/src/main/java/com/swyp/glint/chatting/repository/ChatRoomRepository.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/repository/ChatRoomRepository.java
@@ -1,0 +1,19 @@
+package com.swyp.glint.chatting.repository;
+
+import com.swyp.glint.chatting.domain.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>{
+
+    @Query("""
+            select c 
+            from ChatRoom c
+            where c.meetingId = :meetingId
+        """)
+    Optional<ChatRoom> findByMeetingId(Long meetingId);
+}

--- a/glint/src/main/java/com/swyp/glint/common/exception/InvalidValueException.java
+++ b/glint/src/main/java/com/swyp/glint/common/exception/InvalidValueException.java
@@ -4,4 +4,8 @@ public class InvalidValueException extends BusinessException{
     public InvalidValueException(final ErrorCode errorCode) {
         super(errorCode);
     }
+
+    public InvalidValueException(String message) {
+        super(message, ErrorCode.INVALID_INPUT_VALUE);
+    }
 }

--- a/glint/src/main/java/com/swyp/glint/user/api/UserController.java
+++ b/glint/src/main/java/com/swyp/glint/user/api/UserController.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/user")
+@RequestMapping(path = "/user")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/glint/src/main/java/com/swyp/glint/user/application/UserDetailService.java
+++ b/glint/src/main/java/com/swyp/glint/user/application/UserDetailService.java
@@ -32,8 +32,16 @@ public class UserDetailService {
     }
 
     public UserDetailResponse getUserDetailById(Long userId) {
-        return UserDetailResponse.from(userDetailRepository.findByUserId(userId)
-                .orElseThrow(() -> new NotFoundEntityException("UserDetail with userId: " + userId + " not found")));
+        return UserDetailResponse.from(getUserEntityOrElseThrow(userId));
+    }
+
+    public UserDetail getUserDetail(Long userId) {
+        return getUserEntityOrElseThrow(userId);
+    }
+
+    public UserDetail getUserEntityOrElseThrow(Long userId) {
+        return userDetailRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundEntityException("UserDetail with userId: " + userId + " not found"));
     }
 
 

--- a/glint/src/main/java/com/swyp/glint/user/application/UserFacade.java
+++ b/glint/src/main/java/com/swyp/glint/user/application/UserFacade.java
@@ -1,0 +1,26 @@
+package com.swyp.glint.user.application;
+
+import com.swyp.glint.chatting.domain.UserChat;
+import com.swyp.glint.user.domain.User;
+import com.swyp.glint.user.domain.UserDetail;
+import com.swyp.glint.user.domain.UserDetailAggregation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserFacade {
+
+    private final UserService userService;
+
+    private final UserDetailService userDetailService;
+
+
+    public UserDetailAggregation getUserDetailAggregation(Long userId) {
+        User user = userService.getUserEntity(userId);
+        UserDetail userDetail = userDetailService.getUserDetail(userId);
+
+        return UserDetailAggregation.of(user, userDetail);
+    }
+
+}

--- a/glint/src/main/java/com/swyp/glint/user/application/UserService.java
+++ b/glint/src/main/java/com/swyp/glint/user/application/UserService.java
@@ -10,6 +10,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -27,6 +29,11 @@ public class UserService {
 
     }
 
+    public User getUserEntity(Long id) {
+        return userRepository.findById(id).orElseThrow(() -> new NotFoundEntityException("id : " + id + " not found"));
+
+    }
+
     public User getUserByEmail(String email) {
         return userRepository.findByEmail(email).orElseThrow(() -> new NotFoundEntityException("email : " + email + " not found"));
     }
@@ -40,4 +47,10 @@ public class UserService {
 
         return UserLoginResponse.from(foundUser);
     }
+
+
+    public List<User> getUsers(List<Long> userIds) {
+        return userRepository.findAllById(userIds);
+    }
+
 }

--- a/glint/src/main/java/com/swyp/glint/user/application/dto/UserDetailRequest.java
+++ b/glint/src/main/java/com/swyp/glint/user/application/dto/UserDetailRequest.java
@@ -13,13 +13,16 @@ public record UserDetailRequest(
         String nickname,
 
         @Parameter(description = "성별", example = "MALE|FEMALE", required = true)
-        @Pattern(regexp = "(MALE|FEMALE)") String gender,
+        @Pattern(regexp = "(MALE|FEMALE)")
+        String gender,
 
         @Parameter(description = "생년월일", example = "2000-01-01", required = true)
-        @Pattern(regexp = "^\\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$") String birthdate,
+        @Pattern(regexp = "^\\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$")
+        String birthdate,
 
         @Parameter(description = "키", example = "180", required = true)
-        @Pattern(regexp = "^[0-9]{3}$") String height,
+        @Pattern(regexp = "^[0-9]{3}$")
+        String height,
 
         @Parameter(description = "프로필 이미지", example = "https://glint-image.s3.ap-northeast-2.amazonaws.com/profile/profile_1720106931.png", required = true)
         String profileImage

--- a/glint/src/main/java/com/swyp/glint/user/domain/UserDetailAggregation.java
+++ b/glint/src/main/java/com/swyp/glint/user/domain/UserDetailAggregation.java
@@ -1,0 +1,61 @@
+package com.swyp.glint.user.domain;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class UserDetailAggregation {
+
+    private Long userId;
+
+
+    private String email;
+
+    private String role;
+
+    private String provider;
+
+    private Boolean archived;
+
+    private String nickname;
+
+    private String gender;
+
+    private LocalDate birthdate;
+
+    private Integer height;
+
+    private String profileImage;
+
+    @Builder(access = lombok.AccessLevel.PRIVATE)
+    private UserDetailAggregation(Long userId, String email, String role, String provider, Boolean archived, String nickname, String gender, LocalDate birthdate, Integer height, String profileImage) {
+        this.userId = userId;
+        this.email = email;
+        this.role = role;
+        this.provider = provider;
+        this.archived = archived;
+        this.nickname = nickname;
+        this.gender = gender;
+        this.birthdate = birthdate;
+        this.height = height;
+        this.profileImage = profileImage;
+    }
+
+    public static UserDetailAggregation of(User user, UserDetail userDetail) {
+        return UserDetailAggregation.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .role(user.getRole())
+                .provider(user.getProvider())
+                .archived(user.getArchived())
+                .nickname(userDetail.getNickname())
+                .gender(userDetail.getGender())
+                .birthdate(userDetail.getBirthdate())
+                .height(userDetail.getHeight())
+                .profileImage(userDetail.getProfileImage())
+                .build();
+    }
+}


### PR DESCRIPTION
❗️ 이슈 번호
close #39 

📝 작업 내용
- 채팅 방 생성
- 채팅 저장
- 채팅 리스트 조회



🙇🏻‍♂️ 참고사항!

**활성화 여부 판단**

1. 내미팅 → 채팅 입장시 채팅방 정보 조회
2. 채팅방 정보중 활성화 여부 반환에 따라 채팅 활성화 결정

**참가자 여부 판단**

- 참여 userId 함께 반환

**채팅방 활성화**

1. 미팅방에 입장시 채팅방에 인원추가
2. 인원 추가할 때 인원이 정원일시 채팅방 활성화 상태 변경 (예정)

**채팅방 리스트 조회**

- paging 방식
- no-offset방식
    - lastChatId 사용
    - lastChatId 안보낼경우 최신
    

# 추가 참고

- 추후 Mongo DB로 전환 예정입니다
- 따라서 id가 숫자가 아니라 String으로 변경될 수 있습니다.

