### PR TITLE
fix: #79: 유저 프로필 이미지 함께수정

### DIFF
--- a/glint/src/main/java/com/swyp/glint/chatting/application/dto/response/ChatResponse.java
+++ b/glint/src/main/java/com/swyp/glint/chatting/application/dto/response/ChatResponse.java
@@ -37,6 +37,7 @@ public record ChatResponse(
                 .userId(userDetailAggregation.getUserId())
                 .nickname(userDetailAggregation.getNickname())
                 .sendDate(chat.getSendDate())
+                .userProfileImageUrl(userDetailAggregation.getProfileImage())
                 .build();
     }
 }


### PR DESCRIPTION
- 이미지 프로필 url 반환안하는 현상 수정

❗️ 이슈 번호
close #80 


📝 작업 내용
- 이미지 프로필 url 반환안하는 현상 수정

