### PR TITLE
fix: 로그인시 회원가입, 기존회원 로그인 여부 추가

### DIFF
--- a/glint/src/main/java/com/swyp/glint/user/application/UserService.java
+++ b/glint/src/main/java/com/swyp/glint/user/application/UserService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -48,10 +49,13 @@ public class UserService {
     public UserLoginResponse oauthLoginUser(UserRequest userRequest) {
         User user = userRequest.toEntity();
 
-        User foundUser = userRepository.findByEmail(user.getEmail())
-                .orElseGet(() -> userRepository.save(userRequest.toEntity()));
+        Optional<User> userOptional = userRepository.findByEmail(user.getEmail());
 
-        return UserLoginResponse.from(foundUser);
+        if(userOptional.isPresent()) {
+            return UserLoginResponse.from(userOptional.get(), false);
+        }
+
+        return UserLoginResponse.from(userRepository.save(userRequest.toEntity()), true);
     }
 
 

--- a/glint/src/main/java/com/swyp/glint/user/application/dto/UserLoginResponse.java
+++ b/glint/src/main/java/com/swyp/glint/user/application/dto/UserLoginResponse.java
@@ -2,20 +2,24 @@ package com.swyp.glint.user.application.dto;
 
 import com.swyp.glint.user.domain.User;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record UserLoginResponse(
-        @Parameter(description = "User ID", example = "1", required = true)
+        @Schema(description = "User ID", example = "1", required = true)
         Long id,
-        @Parameter(description = "User Email", example = "glint@gmail.com", required = true)
-        String email
+        @Schema(description = "User Email", example = "glint@gmail.com", required = true)
+        String email,
+        @Schema(description = "기존회원, 회원가입 여부", example = "true", required = true)
+        Boolean isSignUp
 ) {
 
-        public static UserLoginResponse from(User user) {
+        public static UserLoginResponse from(User user, Boolean isSignUp) {
             return UserLoginResponse.builder()
                     .id(user.getId())
                     .email(user.getEmail())
+                    .isSignUp(isSignUp)
                     .build();
         }
 }


### PR DESCRIPTION
❗️ 이슈 번호
close #149 


📝 작업 내용
- 로그인시 회원가입 인지, 기존회원인지 판별 불가
- 회원가입, 기존회원 flag 추가


🙇🏻‍♂️ 참고사항!



💡 참고 자료
